### PR TITLE
fix(wildcard): error when wildcard-matched node does not contain next node

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,14 @@
 module github.com/tristancorbellari/yaml-jsonpointer
 
-go 1.14
+go 1.18
 
 require (
 	github.com/go-openapi/jsonpointer v0.19.3
-	github.com/vmware-labs/yaml-jsonpointer v0.1.1
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
+)
+
+require (
+	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e // indirect
+	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/vmware-labs/yaml-jsonpointer v0.1.1 h1:gO9fa7NgCEGUM/+MhpHlrmh3kNTMzFTmoeBmWSagLz0=
-github.com/vmware-labs/yaml-jsonpointer v0.1.1/go.mod h1:JDtZ8Hd3hkVzyCAoBXxOSfP9aVfUMAG9OSPfgQTvCQk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/yptr_test.go
+++ b/yptr_test.go
@@ -81,7 +81,9 @@ func ExampleFindAll_wildcard() {
 	src := `version: "3.8"
 
 services:
+  some-service:
   test:
+    volume: some_volume # this is a comment
   web:
     image: node
     another: thing
@@ -96,8 +98,8 @@ services:
 		fmt.Printf("Scalar %q at %d:%d\n", r.Value, r.Line, r.Column)
 	}
 
-	// Output: Scalar "node" at 6:12
-	// Scalar "postgres" at 9:12
+	// Output: Scalar "node" at 8:12
+	// Scalar "postgres" at 11:12
 }
 
 func TestParse(t *testing.T) {


### PR DESCRIPTION
Before, the following input would have thrown an error:

```
version: "3.8"

services:
  some-service:
  test:
    volume: some_volume # this is a comment
  web:
    image: node
    another: thing
  db:
    image: postgres
```

...as the `test` service does not contain a child node "image", meaning the next matching stage will fail as it will find no matches. Checking to see whether there are no child nodes (as previously implemented) is not sufficient.

So, this fix adds a lookahead for the next token in the `match` function, to evaluate whether the currently evaluated node contains a child node with the key matching the next token. If so, we can then return the matches safely.